### PR TITLE
Add the logparser install path to the system path

### DIFF
--- a/LogParser/Tools/ChocolateyInstall.ps1
+++ b/LogParser/Tools/ChocolateyInstall.ps1
@@ -1,1 +1,14 @@
-Install-ChocolateyPackage 'logparser' 'msi' '/quiet' 'http://download.microsoft.com/download/f/f/1/ff1819f9-f702-48a5-bbc7-c9656bc74de8/LogParser.msi'
+$name = 'logparser'
+$is64bit = (Get-WmiObject Win32_Processor).AddressWidth -eq 64
+$proram_files = if($is64bit){ ${ENV:PROGRAMFILES(X86)} } else{ $ENV:PROGRAMFILES }
+
+try {
+
+  Install-ChocolateyPackage $name 'msi' '/quiet' 'http://download.microsoft.com/download/f/f/1/ff1819f9-f702-48a5-bbc7-c9656bc74de8/LogParser.msi'
+  Install-ChocolateyPath (Join-Path $program_files 'Log Parser 2.2')
+
+  Write-ChocolateySuccess $name
+} catch {
+  Write-ChocolateyFailure $name $($_.Exception.Message)
+  throw 
+}


### PR DESCRIPTION
This way, you don't have to use the custom shell that they link in the Start Menu. The logparser.exe will work from anywhere. The installer always puts the executable in the 32bit Program Files, which requires some testing in the install script.
