### PR TITLE
VisualStudio2017*: update to RC 2017-02-07, update dependencies, use extension

### DIFF
--- a/VisualStudio2017Community/Tools/ChocolateyInstall.ps1
+++ b/VisualStudio2017Community/Tools/ChocolateyInstall.ps1
@@ -1,9 +1,8 @@
-Import-Module (Join-Path $(Split-Path -parent $MyInvocation.MyCommand.Definition) 'VSModules.psm1')
-
-Install-VS `
+Install-VisualStudio `
     -PackageName 'VisualStudio2017Community' `
-    -ApplicationName 'Microsoft Visual Studio Community 2017' `
-    -Url 'https://aka.ms/vs/15/release/vs_Community.exe' `
-    -ChecksumSha1 '183f56b2989020750f6f5c5c422284019c178c1d' `
-    -AssumeNewVS2017Installer `
-    -InstallerDisplayName 'Microsoft Visual Studio Installer'
+    -ApplicationName 'Microsoft Visual Studio Community 2017 RC' `
+    -Url 'https://download.microsoft.com/download/7/6/6/766DFD1B-5E54-4F2E-82BF-FAAADD4F3401/vs_Community.exe' `
+    -Checksum 'AC856CD48905A7D162EAB6DAFFDFCF3745D5C843' `
+    -ChecksumType 'SHA1' `
+    -InstallerTechnology 'WillowVS2017OrLater' `
+    -ProgramsAndFeaturesDisplayName 'Microsoft Visual Studio 2017'

--- a/VisualStudio2017Community/Tools/ChocolateyInstall.ps1
+++ b/VisualStudio2017Community/Tools/ChocolateyInstall.ps1
@@ -1,8 +1,8 @@
 Install-VisualStudio `
     -PackageName 'VisualStudio2017Community' `
-    -ApplicationName 'Microsoft Visual Studio Community 2017 RC' `
-    -Url 'https://download.microsoft.com/download/7/6/6/766DFD1B-5E54-4F2E-82BF-FAAADD4F3401/vs_Community.exe' `
-    -Checksum 'AC856CD48905A7D162EAB6DAFFDFCF3745D5C843' `
-    -ChecksumType 'SHA1' `
+    -ApplicationName 'Microsoft Visual Studio Community 2017' `
+    -Url 'https://download.microsoft.com/download/9/D/2/9D228A37-56C0-48D7-B1B4-486090DE7C2A/vs_Community.exe' `
+    -Checksum '2C09F31BF870D9073FD707EA4CB1700E7191C4D9E5D5A3AD9F43F0DAFFF2E856' `
+    -ChecksumType 'SHA256' `
     -InstallerTechnology 'WillowVS2017OrLater' `
     -ProgramsAndFeaturesDisplayName 'Microsoft Visual Studio 2017'

--- a/VisualStudio2017Community/Tools/ChocolateyInstall.ps1
+++ b/VisualStudio2017Community/Tools/ChocolateyInstall.ps1
@@ -1,8 +1,8 @@
 Install-VisualStudio `
     -PackageName 'VisualStudio2017Community' `
     -ApplicationName 'Microsoft Visual Studio Community 2017' `
-    -Url 'https://download.microsoft.com/download/9/D/2/9D228A37-56C0-48D7-B1B4-486090DE7C2A/vs_Community.exe' `
-    -Checksum '2C09F31BF870D9073FD707EA4CB1700E7191C4D9E5D5A3AD9F43F0DAFFF2E856' `
+    -Url 'https://download.microsoft.com/download/5/2/1/521C52A7-EFCC-46CE-A890-4F317732ABA3/vs_Community.exe' `
+    -Checksum 'A964FA078C0FA9115001302FF80D8119995814B58322646A46C4F3B894479471' `
     -ChecksumType 'SHA256' `
     -InstallerTechnology 'WillowVS2017OrLater' `
     -ProgramsAndFeaturesDisplayName 'Microsoft Visual Studio 2017'

--- a/VisualStudio2017Community/Tools/ChocolateyUninstall.ps1
+++ b/VisualStudio2017Community/Tools/ChocolateyUninstall.ps1
@@ -1,6 +1,4 @@
-Uninstall-VisualStudio `
-    -PackageName 'VisualStudio2017Community' `
-    -ApplicationName 'Microsoft Visual Studio Community 2017 RC' `
-    -UninstallerName 'vs_installer.exe' `
-    -InstallerTechnology 'WillowVS2017OrLater' `
-    -ProgramsAndFeaturesDisplayName 'Microsoft Visual Studio 2017'
+Remove-VisualStudioProduct `
+    -PackageName 'VisualStudio2017Community' `
+    -Product 'Community' `
+    -VisualStudioYear '2017'

--- a/VisualStudio2017Community/Tools/ChocolateyUninstall.ps1
+++ b/VisualStudio2017Community/Tools/ChocolateyUninstall.ps1
@@ -1,6 +1,6 @@
-Uninstall-VS `
+Uninstall-VisualStudio `
     -PackageName 'VisualStudio2017Community' `
-    -ApplicationName 'Microsoft Visual Studio Community 2017' `
+    -ApplicationName 'Microsoft Visual Studio Community 2017 RC' `
     -UninstallerName 'vs_installer.exe' `
-    -AssumeNewVS2017Installer `
-    -InstallerDisplayName 'Microsoft Visual Studio Installer'
+    -InstallerTechnology 'WillowVS2017OrLater' `
+    -ProgramsAndFeaturesDisplayName 'Microsoft Visual Studio 2017'

--- a/VisualStudio2017Community/VisualStudioCommunity2017.nuspec
+++ b/VisualStudio2017Community/VisualStudioCommunity2017.nuspec
@@ -3,10 +3,10 @@
   <metadata>
     <id>VisualStudio2017Community</id>
     <title>Visual Studio 2017 Community</title>
-    <version>15.0.26228.20170331</version>
+    <version>15.1.26403.20170405</version>
     <authors>Microsoft</authors>
     <owners>Jivko Kolev,jberezanski</owners>
-    <projectUrl>https://blogs.msdn.microsoft.com/visualstudio/2017/03/07/announcing-visual-studio-2017-general-availability-and-more/</projectUrl>
+    <projectUrl>https://blogs.msdn.microsoft.com/visualstudio/2017/04/05/visual-studio-2017-update/</projectUrl>
     <iconUrl>https://cdn.rawgit.com/jberezanski/ChocolateyPackages/17d25f2fb8a31d40b93a696e345c22a77913418f/icons/vs2017.png</iconUrl>
     <licenseUrl>https://www.visualstudio.com/license-terms/mlt553321/</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -55,7 +55,7 @@ If control over reboots is required, please install the dependencies (like dotne
     <releaseNotes>##### Software
 [Visual Studio 2017 release notes](https://www.visualstudio.com/en-us/news/releasenotes/vs2017-relnotes)
 ##### Package
-15.0.26228.20170331: Initial package release for Visual Studio 2017 version 15.0.26228.12.
+15.1.26403.20170405: Package metadata updated for Visual Studio 2017 version 15.1.26403.0 (the native installer always installs the latest released Visual Studio 2017 build).
 </releaseNotes>
     <tags>Microsoft Visual Studio 2017 Community IDE VisualStudio VS VS15 admin</tags>
     <dependencies>

--- a/VisualStudio2017Community/VisualStudioCommunity2017.nuspec
+++ b/VisualStudio2017Community/VisualStudioCommunity2017.nuspec
@@ -2,13 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>VisualStudio2017Community</id>
-    <title>Visual Studio 2017 Community - Release Candidate (2017-02-07)</title>
-    <version>15.0.26206.20170228-rc6</version>
+    <title>Visual Studio 2017 Community</title>
+    <version>15.0.26228.0</version>
     <authors>Microsoft</authors>
     <owners>Jivko Kolev,jberezanski</owners>
-    <projectUrl>https://www.visualstudio.com/vs/visual-studio-2017-rc</projectUrl>
-    <iconUrl>https://github.com/jivkok/Chocolatey-Packages/raw/master/VisualStudioCommon/VS2015.png</iconUrl>
-    <licenseUrl>http://msdn.microsoft.com/en-US/cc300389.aspx</licenseUrl>
+    <projectUrl>https://blogs.msdn.microsoft.com/visualstudio/2017/03/07/announcing-visual-studio-2017-general-availability-and-more/</projectUrl>
+    <iconUrl>https://cdn.rawgit.com/jberezanski/ChocolateyPackages/17d25f2fb8a31d40b93a696e345c22a77913418f/icons/vs2017.png</iconUrl>
+    <licenseUrl>https://www.visualstudio.com/license-terms/mlt553321/</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Free, full-featured and extensible tool for students, open-source and individual developers</summary>
     <description>### Overview
@@ -27,37 +27,55 @@ Built-in suite of Azure tools that enable developers to easily create cloud-firs
 With advanced debugging and profiling tools and unit test generation features, Visual Studio 2017 with Xamarin makes it faster and easier than ever for developers to build, connect, and tune mobile apps for Android, iOS, and Windows. Developer can also choose to develop mobile apps with Apache Cordova or Visual C++ cross platform library development in Visual Studio.
 
 ### Customizations and Optional features
-By default, the package installs only the bare minimum required (the Core Editor workload). The easiest way to add more workloads is to use the workload packages: `visualstudio2017-workload-*`, e.g. [visualstudio2017-workload-manageddesktop](https://chocolatey.org/packages/visualstudio2017-workload-manageddesktop).
+By default, the package installs only the bare minimum required (the Core Editor workload). The easiest way to add more workloads (feature sets) is to use the workload packages:
+- [Azure development](https://chocolatey.org/packages/visualstudio2017-workload-azure)
+- [Data storage and processing](https://chocolatey.org/packages/visualstudio2017-workload-data)
+- [.NET desktop development](https://chocolatey.org/packages/visualstudio2017-workload-manageddesktop)
+- [Game development with Unity](https://chocolatey.org/packages/visualstudio2017-workload-managedgame)
+- [Linux development with C++](https://chocolatey.org/packages/visualstudio2017-workload-nativecrossplat)
+- [Desktop development with C++](https://chocolatey.org/packages/visualstudio2017-workload-nativedesktop)
+- [Game development with C++](https://chocolatey.org/packages/visualstudio2017-workload-nativegame)
+- [Mobile development with C++](https://chocolatey.org/packages/visualstudio2017-workload-nativemobile)
+- [.NET Core cross-platform development](https://chocolatey.org/packages/visualstudio2017-workload-netcoretools)
+- [Mobile development with .NET](https://chocolatey.org/packages/visualstudio2017-workload-netcrossplat)
+- [ASP.NET and web development](https://chocolatey.org/packages/visualstudio2017-workload-netweb)
+- [Node.js development](https://chocolatey.org/packages/visualstudio2017-workload-node)
+- [Universal Windows Platform development](https://chocolatey.org/packages/visualstudio2017-workload-universal)
+- [Visual Studio extension development](https://chocolatey.org/packages/visualstudio2017-workload-visualstudioextension)
+- [Mobile development with JavaScript](https://chocolatey.org/packages/visualstudio2017-workload-webcrossplat)
 
 However, the package passes all package parameters to the Visual Studio installer, enabling full customization of the installation. The possible parameters are [described here](https://docs.microsoft.com/en-us/visualstudio/install/use-command-line-parameters-to-install-visual-studio). The package passes `--norestart --wait` by default, and `--quiet`, unless `--passive` is specified in the package parameters.
 
 After installing the package, more workloads/components can also be added interactively, by launching the Visual Studio Installer application from the Start Menu.
 
-#### Full installation
-As an example of using package parameters, this command will install Visual Studio with all available workloads and optional components and display progress during the installation:
+The language of the installed software can be controlled using the package parameter `--locale &lt;language&gt;`.
+The list of supported languages is [presented here](https://docs.microsoft.com/en-us/visualstudio/install/use-command-line-parameters-to-install-visual-studio#list-of-language-locales). By default, the operating system display language is used.
 
-    choco install visualstudio2017professional -packageParameters "--allWorkloads --includeRecommended --includeOptional --passive"
+#### Full installation
+As an example of using package parameters, this command will install Visual Studio with all available workloads and optional components, display progress during the installation and specify the English language regardless of operating system settings:
+
+    choco install visualstudio2017professional --package-parameters "--allWorkloads --includeRecommended --includeOptional --passive --locale en-US"
 
 ### Installation notes
 
 A reboot may be required after installing/uninstalling this package. A reboot might even be required _before_ installing/uninstalling - if the system is awaiting a reboot due to Windows updates having been installed, or if you are attempting to uninstall the package immediately after installing it. The package will provide informative messages in each case.
 
-If control over reboots is required, please install the dependencies (like dotnet4.6 or later) first, perform a reboot if needed, and then continue with the VS package install.
+If control over reboots is required, please install the dependencies (like dotnet4.6.1 or later) first, perform a reboot if needed, and then continue with the VS package install.
 </description>
     <releaseNotes>##### Software
-[Visual Studio 2017 RC release notes](https://www.visualstudio.com/news/releasenotes/vs15-relnotes)
+[Visual Studio 2017 release notes](https://www.visualstudio.com/en-us/news/releasenotes/vs2017-relnotes)
 </releaseNotes>
-    <tags>Microsoft Visual Studio 2017 Community IDE VisualStudio VS VS15</tags>
+    <tags>Microsoft Visual Studio 2017 Community IDE VisualStudio VS VS15 admin</tags>
     <dependencies>
-      <dependency id="chocolatey-visualstudio.extension" version="1.1.0" />
+      <dependency id="chocolatey-visualstudio.extension" version="1.2.0" />
       <dependency id="KB3033929" version="1.0.0" />
       <dependency id="KB2919355" version="1.0.20160915" />
       <dependency id="KB2999226" version="1.0.20161201" />
-      <dependency id="dotnet4.6" version="4.6.00081.20150925" />
-      <dependency id="visualstudio2017-installer" version="1.0.0-rc1" />
+      <dependency id="dotnet4.6.1" version="4.6.01055.20161213" />
+      <dependency id="visualstudio2017-installer" version="1.0.0" />
     </dependencies>
     <packageSourceUrl>https://github.com/jivkok/Chocolatey-Packages/tree/master/VisualStudio2017Community</packageSourceUrl>
-    <docsUrl>https://www.visualstudio.com/en-us/news/releasenotes/vs15-relnotes</docsUrl>
+    <docsUrl>https://docs.microsoft.com/en-us/visualstudio/welcome-to-visual-studio</docsUrl>
     <bugTrackerUrl>https://visualstudio.uservoice.com/forums/121579-visual-studio</bugTrackerUrl>
   </metadata>
   <files>

--- a/VisualStudio2017Community/VisualStudioCommunity2017.nuspec
+++ b/VisualStudio2017Community/VisualStudioCommunity2017.nuspec
@@ -14,20 +14,11 @@
     <description>### Overview
 Free, full-featured and extensible tool for students, open-source and individual developers.
 
-#### Boosted productivity
-Enhancements to code navigation, IntelliSense, refactoring, code fixes, and debugging, saves you time and effort on everyday tasks regardless of language or platform. In addition, for teams embracing DevOps, Visual Studio 2017 streamlines the developer inner loop and speeds up code flow with the brand new real time features such as live unit testing and real-time architectural dependency validation.
-
-#### Redefined fundamentals
-There is a renewed focus to enhance the efficiency of the fundamental tasks developers encounter on daily basis. From a brand-new lightweight and modular installation tailored to developers’ need, a faster IDE from startup to shut down, to a new way of view, edit, and debug any code without projects and solutions. Visual Studio 2017 helps developers stay focused on the big picture.
-
-#### Streamlined Azure development
-Built-in suite of Azure tools that enable developers to easily create cloud-first applications powered by Microsoft Azure. Visual Studio makes it easy to configure, build, debug, package, and deploy applications and services on Microsoft Azure directly from the IDE.
-
-#### Five-star mobile development
-With advanced debugging and profiling tools and unit test generation features, Visual Studio 2017 with Xamarin makes it faster and easier than ever for developers to build, connect, and tune mobile apps for Android, iOS, and Windows. Developer can also choose to develop mobile apps with Apache Cordova or Visual C++ cross platform library development in Visual Studio.
+To find out what's new or to see the known issues, see the [Visual Studio 2017 Release Notes](https://www.visualstudio.com/en-us/news/releasenotes/vs2017-relnotes).  
+[System requirements](https://www.visualstudio.com/en-us/productinfo/vs2017-system-requirements-vs)
 
 ### Customizations and Optional features
-By default, the package installs only the bare minimum required (the Core Editor workload). The easiest way to add more workloads (feature sets) is to use the workload packages:
+By default, the package installs only the bare minimum required (the Core Editor workload). The easiest way to add more development features is to use the workload packages:
 - [Azure development](https://chocolatey.org/packages/visualstudio2017-workload-azure)
 - [Data storage and processing](https://chocolatey.org/packages/visualstudio2017-workload-data)
 - [.NET desktop development](https://chocolatey.org/packages/visualstudio2017-workload-manageddesktop)
@@ -44,22 +35,21 @@ By default, the package installs only the bare minimum required (the Core Editor
 - [Visual Studio extension development](https://chocolatey.org/packages/visualstudio2017-workload-visualstudioextension)
 - [Mobile development with JavaScript](https://chocolatey.org/packages/visualstudio2017-workload-webcrossplat)
 
-However, the package passes all package parameters to the Visual Studio installer, enabling full customization of the installation. The possible parameters are [described here](https://docs.microsoft.com/en-us/visualstudio/install/use-command-line-parameters-to-install-visual-studio). The package passes `--norestart --wait` by default, and `--quiet`, unless `--passive` is specified in the package parameters.
+All package parameters are passed to the Visual Studio installer, enabling full customization of the installation. The possible parameters are [described here](https://docs.microsoft.com/en-us/visualstudio/install/use-command-line-parameters-to-install-visual-studio). The package passes `--norestart --wait` by default, and `--quiet`, unless `--passive` is specified in the package parameters.
 
-After installing the package, more workloads/components can also be added interactively, by launching the Visual Studio Installer application from the Start Menu.
+After installing the package, more features can also be added by launching the Visual Studio Installer application from the Start Menu.
 
 The language of the installed software can be controlled using the package parameter `--locale &lt;language&gt;`.
-The list of supported languages is [presented here](https://docs.microsoft.com/en-us/visualstudio/install/use-command-line-parameters-to-install-visual-studio#list-of-language-locales). By default, the operating system display language is used.
+The list of languages is [presented here](https://docs.microsoft.com/en-us/visualstudio/install/use-command-line-parameters-to-install-visual-studio#list-of-language-locales). By default, the operating system display language is used.
 
 #### Full installation
-As an example of using package parameters, this command will install Visual Studio with all available workloads and optional components, display progress during the installation and specify the English language regardless of operating system settings:
+This command will install Visual Studio with all available workloads and optional components, display progress during the installation and specify the English language regardless of operating system settings:
 
-    choco install visualstudio2017professional --package-parameters "--allWorkloads --includeRecommended --includeOptional --passive --locale en-US"
+    choco install visualstudio2017community --package-parameters "--allWorkloads --includeRecommended --includeOptional --passive --locale en-US"
 
-### Installation notes
+### Notes
 
-A reboot may be required after installing/uninstalling this package. A reboot might even be required _before_ installing/uninstalling - if the system is awaiting a reboot due to Windows updates having been installed, or if you are attempting to uninstall the package immediately after installing it. The package will provide informative messages in each case.
-
+A reboot may be required after (or even _before_) installing/uninstalling this package.
 If control over reboots is required, please install the dependencies (like dotnet4.6.1 or later) first, perform a reboot if needed, and then continue with the VS package install.
 </description>
     <releaseNotes>##### Software

--- a/VisualStudio2017Community/VisualStudioCommunity2017.nuspec
+++ b/VisualStudio2017Community/VisualStudioCommunity2017.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>VisualStudio2017Community</id>
     <title>Visual Studio 2017 Community</title>
-    <version>15.0.26228.0</version>
+    <version>15.0.26228.20170331</version>
     <authors>Microsoft</authors>
     <owners>Jivko Kolev,jberezanski</owners>
     <projectUrl>https://blogs.msdn.microsoft.com/visualstudio/2017/03/07/announcing-visual-studio-2017-general-availability-and-more/</projectUrl>
@@ -54,6 +54,8 @@ If control over reboots is required, please install the dependencies (like dotne
 </description>
     <releaseNotes>##### Software
 [Visual Studio 2017 release notes](https://www.visualstudio.com/en-us/news/releasenotes/vs2017-relnotes)
+##### Package
+15.0.26228.20170331: Initial package release for Visual Studio 2017 version 15.0.26228.12.
 </releaseNotes>
     <tags>Microsoft Visual Studio 2017 Community IDE VisualStudio VS VS15 admin</tags>
     <dependencies>

--- a/VisualStudio2017Community/VisualStudioCommunity2017.nuspec
+++ b/VisualStudio2017Community/VisualStudioCommunity2017.nuspec
@@ -3,9 +3,9 @@
   <metadata>
     <id>VisualStudio2017Community</id>
     <title>Visual Studio 2017 Community - Release Candidate (2017-02-07)</title>
-    <version>15.0.26206.20170214-rc6</version>
+    <version>15.0.26206.20170228-rc6</version>
     <authors>Microsoft</authors>
-    <owners>Jivko Kolev</owners>
+    <owners>Jivko Kolev,jberezanski</owners>
     <projectUrl>https://www.visualstudio.com/vs/visual-studio-2017-rc</projectUrl>
     <iconUrl>https://github.com/jivkok/Chocolatey-Packages/raw/master/VisualStudioCommon/VS2015.png</iconUrl>
     <licenseUrl>http://msdn.microsoft.com/en-US/cc300389.aspx</licenseUrl>
@@ -49,11 +49,12 @@ If control over reboots is required, please install the dependencies (like dotne
 </releaseNotes>
     <tags>Microsoft Visual Studio 2017 Community IDE VisualStudio VS VS15</tags>
     <dependencies>
-      <dependency id="chocolatey-visualstudio.extension" version="1.0.0" />
+      <dependency id="chocolatey-visualstudio.extension" version="1.1.0" />
       <dependency id="KB3033929" version="1.0.0" />
       <dependency id="KB2919355" version="1.0.20160915" />
       <dependency id="KB2999226" version="1.0.20161201" />
       <dependency id="dotnet4.6" version="4.6.00081.20150925" />
+      <dependency id="visualstudio2017-installer" version="1.0.0-rc1" />
     </dependencies>
     <packageSourceUrl>https://github.com/jivkok/Chocolatey-Packages/tree/master/VisualStudio2017Community</packageSourceUrl>
     <docsUrl>https://www.visualstudio.com/en-us/news/releasenotes/vs15-relnotes</docsUrl>

--- a/VisualStudio2017Community/VisualStudioCommunity2017.nuspec
+++ b/VisualStudio2017Community/VisualStudioCommunity2017.nuspec
@@ -2,8 +2,8 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>VisualStudio2017Community</id>
-    <title>Visual Studio 2017 Community - Release Candidate</title>
-    <version>15.0.25914.20161116-RC</version>
+    <title>Visual Studio 2017 Community - Release Candidate (2017-02-07)</title>
+    <version>15.0.26206.20170214-rc6</version>
     <authors>Microsoft</authors>
     <owners>Jivko Kolev</owners>
     <projectUrl>https://www.visualstudio.com/vs/visual-studio-2017-rc</projectUrl>
@@ -27,13 +27,20 @@ Built-in suite of Azure tools that enable developers to easily create cloud-firs
 With advanced debugging and profiling tools and unit test generation features, Visual Studio 2017 with Xamarin makes it faster and easier than ever for developers to build, connect, and tune mobile apps for Android, iOS, and Windows. Developer can also choose to develop mobile apps with Apache Cordova or Visual C++ cross platform library development in Visual Studio.
 
 ### Customizations and Optional features
-Not yet. Expect them in the final released version.
+By default, the package installs only the bare minimum required (the Core Editor workload). The easiest way to add more workloads is to use the workload packages: `visualstudio2017-workload-*`, e.g. [visualstudio2017-workload-manageddesktop](https://chocolatey.org/packages/visualstudio2017-workload-manageddesktop).
+
+However, the package passes all package parameters to the Visual Studio installer, enabling full customization of the installation. The possible parameters are [described here](https://docs.microsoft.com/en-us/visualstudio/install/use-command-line-parameters-to-install-visual-studio). The package passes `--norestart --wait` by default, and `--quiet`, unless `--passive` is specified in the package parameters.
+
+After installing the package, more workloads/components can also be added interactively, by launching the Visual Studio Installer application from the Start Menu.
+
+#### Full installation
+As an example of using package parameters, this command will install Visual Studio with all available workloads and optional components and display progress during the installation:
+
+    choco install visualstudio2017professional -packageParameters "--allWorkloads --includeRecommended --includeOptional --passive"
 
 ### Installation notes
 
-**IMPORTANT**: This release uses the new Visual Studio installer, which does not support unattended installation yet. Therefore, the installation of this page will require user interaction.
-
-A reboot will most certainly be required after installing/uninstalling this package. A reboot might even be required _before_ installing/uninstalling - if the system is awaiting a reboot due to Windows updates having been installed, or if you are attempting to uninstall the package immediately after installing it. The package will provide informative messages in each case.
+A reboot may be required after installing/uninstalling this package. A reboot might even be required _before_ installing/uninstalling - if the system is awaiting a reboot due to Windows updates having been installed, or if you are attempting to uninstall the package immediately after installing it. The package will provide informative messages in each case.
 
 If control over reboots is required, please install the dependencies (like dotnet4.6 or later) first, perform a reboot if needed, and then continue with the VS package install.
 </description>
@@ -42,11 +49,11 @@ If control over reboots is required, please install the dependencies (like dotne
 </releaseNotes>
     <tags>Microsoft Visual Studio 2017 Community IDE VisualStudio VS VS15</tags>
     <dependencies>
+      <dependency id="chocolatey-visualstudio.extension" version="1.0.0" />
       <dependency id="KB3033929" version="1.0.0" />
       <dependency id="KB2919355" version="1.0.20160915" />
-      <dependency id="vcredist2012" version="11.0.60610" />
-      <dependency id="vcredist2015" version="14.0.24215.20160928" />
-      <dependency id="dotnet4.6.1" version="4.6.1055.1" />
+      <dependency id="KB2999226" version="1.0.20161201" />
+      <dependency id="dotnet4.6" version="4.6.00081.20150925" />
     </dependencies>
     <packageSourceUrl>https://github.com/jivkok/Chocolatey-Packages/tree/master/VisualStudio2017Community</packageSourceUrl>
     <docsUrl>https://www.visualstudio.com/en-us/news/releasenotes/vs15-relnotes</docsUrl>
@@ -54,6 +61,5 @@ If control over reboots is required, please install the dependencies (like dotne
   </metadata>
   <files>
     <file src="Tools\*" target="Tools\" />
-    <file src="..\VisualStudioCommon\VSModules2017.psm1" target="Tools\VSModules.psm1" />
   </files>
 </package>

--- a/VisualStudio2017Professional/Tools/ChocolateyInstall.ps1
+++ b/VisualStudio2017Professional/Tools/ChocolateyInstall.ps1
@@ -1,8 +1,8 @@
 Install-VisualStudio `
     -PackageName 'VisualStudio2017Professional' `
-    -ApplicationName 'Microsoft Visual Studio Professional 2017 RC' `
-    -Url 'https://download.microsoft.com/download/0/C/3/0C3F5C94-40C4-4BF4-8D18-BEEAF47AE687/vs_Professional.exe' `
-    -Checksum '886381C79E6638446B402BCB1229681E5B6B1E76' `
-    -ChecksumType 'SHA1' `
+    -ApplicationName 'Microsoft Visual Studio Professional 2017' `
+    -Url 'https://download.microsoft.com/download/0/2/7/0271BCD5-7A78-41F9-BABE-2194B9B83840/vs_Professional.exe' `
+    -Checksum '5B03486FE61F3B5B7B0AA4059741BBF7B7652C89BFFCFB8ED6F99E07889B6752' `
+    -ChecksumType 'SHA256' `
     -InstallerTechnology 'WillowVS2017OrLater' `
     -ProgramsAndFeaturesDisplayName 'Microsoft Visual Studio 2017'

--- a/VisualStudio2017Professional/Tools/ChocolateyInstall.ps1
+++ b/VisualStudio2017Professional/Tools/ChocolateyInstall.ps1
@@ -1,8 +1,8 @@
 Install-VisualStudio `
     -PackageName 'VisualStudio2017Professional' `
     -ApplicationName 'Microsoft Visual Studio Professional 2017' `
-    -Url 'https://download.microsoft.com/download/0/2/7/0271BCD5-7A78-41F9-BABE-2194B9B83840/vs_Professional.exe' `
-    -Checksum '5B03486FE61F3B5B7B0AA4059741BBF7B7652C89BFFCFB8ED6F99E07889B6752' `
+    -Url 'https://download.microsoft.com/download/C/5/0/C5092724-4FFE-4DD3-9EE7-0AE31BF17620/vs_Professional.exe' `
+    -Checksum 'EB4FC0A0C9C55AFDF86CF4D53625A41F554A4A49A7EDCAC6C9CFDFDC34FE1722' `
     -ChecksumType 'SHA256' `
     -InstallerTechnology 'WillowVS2017OrLater' `
     -ProgramsAndFeaturesDisplayName 'Microsoft Visual Studio 2017'

--- a/VisualStudio2017Professional/Tools/ChocolateyInstall.ps1
+++ b/VisualStudio2017Professional/Tools/ChocolateyInstall.ps1
@@ -1,9 +1,8 @@
-Import-Module (Join-Path $(Split-Path -parent $MyInvocation.MyCommand.Definition) 'VSModules.psm1')
-
-Install-VS `
+Install-VisualStudio `
     -PackageName 'VisualStudio2017Professional' `
-    -ApplicationName 'Microsoft Visual Studio Professional 2017' `
-    -Url 'https://aka.ms/vs/15/release/vs_Professional.exe' `
-    -ChecksumSha1 '2a8511d873e0f204c8357851749a245292bc0b4b' `
-    -AssumeNewVS2017Installer `
-    -InstallerDisplayName 'Microsoft Visual Studio Installer'
+    -ApplicationName 'Microsoft Visual Studio Professional 2017 RC' `
+    -Url 'https://download.microsoft.com/download/0/C/3/0C3F5C94-40C4-4BF4-8D18-BEEAF47AE687/vs_Professional.exe' `
+    -Checksum '886381C79E6638446B402BCB1229681E5B6B1E76' `
+    -ChecksumType 'SHA1' `
+    -InstallerTechnology 'WillowVS2017OrLater' `
+    -ProgramsAndFeaturesDisplayName 'Microsoft Visual Studio 2017'

--- a/VisualStudio2017Professional/Tools/ChocolateyUninstall.ps1
+++ b/VisualStudio2017Professional/Tools/ChocolateyUninstall.ps1
@@ -1,6 +1,6 @@
-Uninstall-VS `
+Uninstall-VisualStudio `
     -PackageName 'VisualStudio2017Professional' `
-    -ApplicationName 'Microsoft Visual Studio Professional 2017' `
+    -ApplicationName 'Microsoft Visual Studio Professional 2017 RC' `
     -UninstallerName 'vs_installer.exe' `
-    -AssumeNewVS2017Installer `
-    -InstallerDisplayName 'Microsoft Visual Studio Installer'
+    -InstallerTechnology 'WillowVS2017OrLater' `
+    -ProgramsAndFeaturesDisplayName 'Microsoft Visual Studio 2017'

--- a/VisualStudio2017Professional/Tools/ChocolateyUninstall.ps1
+++ b/VisualStudio2017Professional/Tools/ChocolateyUninstall.ps1
@@ -1,6 +1,4 @@
-Uninstall-VisualStudio `
-    -PackageName 'VisualStudio2017Professional' `
-    -ApplicationName 'Microsoft Visual Studio Professional 2017 RC' `
-    -UninstallerName 'vs_installer.exe' `
-    -InstallerTechnology 'WillowVS2017OrLater' `
-    -ProgramsAndFeaturesDisplayName 'Microsoft Visual Studio 2017'
+Remove-VisualStudioProduct `
+    -PackageName 'VisualStudio2017Professional' `
+    -Product 'Professional' `
+    -VisualStudioYear '2017'

--- a/VisualStudio2017Professional/VisualStudioProfessional2017.nuspec
+++ b/VisualStudio2017Professional/VisualStudioProfessional2017.nuspec
@@ -3,10 +3,10 @@
   <metadata>
     <id>VisualStudio2017Professional</id>
     <title>Visual Studio 2017 Professional</title>
-    <version>15.0.26228.20170331</version>
+    <version>15.1.26403.20170405</version>
     <authors>Microsoft</authors>
     <owners>Jivko Kolev,jberezanski</owners>
-    <projectUrl>https://blogs.msdn.microsoft.com/visualstudio/2017/03/07/announcing-visual-studio-2017-general-availability-and-more/</projectUrl>
+    <projectUrl>https://blogs.msdn.microsoft.com/visualstudio/2017/04/05/visual-studio-2017-update/</projectUrl>
     <iconUrl>https://cdn.rawgit.com/jberezanski/ChocolateyPackages/17d25f2fb8a31d40b93a696e345c22a77913418f/icons/vs2017.png</iconUrl>
     <licenseUrl>https://www.visualstudio.com/license-terms/mlt687465/</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -56,7 +56,7 @@ If control over reboots is required, please install the dependencies (like dotne
     <releaseNotes>##### Software
 [Visual Studio 2017 release notes](https://www.visualstudio.com/en-us/news/releasenotes/vs2017-relnotes)
 ##### Package
-15.0.26228.20170331: Initial package release for Visual Studio 2017 version 15.0.26228.12.
+15.1.26403.20170405: Package metadata updated for Visual Studio 2017 version 15.1.26403.0 (the native installer always installs the latest released Visual Studio 2017 build).
 </releaseNotes>
     <tags>Microsoft Visual Studio 2017 Professional IDE VisualStudio VS VS15 admin</tags>
     <dependencies>

--- a/VisualStudio2017Professional/VisualStudioProfessional2017.nuspec
+++ b/VisualStudio2017Professional/VisualStudioProfessional2017.nuspec
@@ -2,8 +2,8 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>VisualStudio2017Professional</id>
-    <title>Visual Studio 2017 Professional - Release Candidate</title>
-    <version>15.0.25914.20161116-RC</version>
+    <title>Visual Studio 2017 Professional - Release Candidate (2017-02-07)</title>
+    <version>15.0.26206.20170214-rc6</version>
     <authors>Microsoft</authors>
     <owners>Jivko Kolev</owners>
     <projectUrl>https://www.visualstudio.com/vs/visual-studio-2017-rc</projectUrl>
@@ -27,13 +27,20 @@ Built-in suite of Azure tools that enable developers to easily create cloud-firs
 With advanced debugging and profiling tools and unit test generation features, Visual Studio 2017 with Xamarin makes it faster and easier than ever for developers to build, connect, and tune mobile apps for Android, iOS, and Windows. Developer can also choose to develop mobile apps with Apache Cordova or Visual C++ cross platform library development in Visual Studio.
 
 ### Customizations and Optional features
-Not yet. Expect them in the final released version.
+By default, the package installs only the bare minimum required (the Core Editor workload). The easiest way to add more workloads is to use the workload packages: `visualstudio2017-workload-*`, e.g. [visualstudio2017-workload-manageddesktop](https://chocolatey.org/packages/visualstudio2017-workload-manageddesktop).
+
+However, the package passes all package parameters to the Visual Studio installer, enabling full customization of the installation. The possible parameters are [described here](https://docs.microsoft.com/en-us/visualstudio/install/use-command-line-parameters-to-install-visual-studio). The package passes `--norestart --wait` by default, and `--quiet`, unless `--passive` is specified in the package parameters.
+
+After installing the package, more workloads/components can also be added interactively, by launching the Visual Studio Installer application from the Start Menu.
+
+#### Full installation
+As an example of using package parameters, this command will install Visual Studio with all available workloads and optional components and display progress during the installation:
+
+    choco install visualstudio2017professional -packageParameters "--allWorkloads --includeRecommended --includeOptional --passive"
 
 ### Installation notes
 
-**IMPORTANT**: This release uses the new Visual Studio installer, which does not support unattended installation yet. Therefore, the installation of this page will require user interaction.
-
-A reboot will most certainly be required after installing/uninstalling this package. A reboot might even be required _before_ installing/uninstalling - if the system is awaiting a reboot due to Windows updates having been installed, or if you are attempting to uninstall the package immediately after installing it. The package will provide informative messages in each case.
+A reboot may be required after installing/uninstalling this package. A reboot might even be required _before_ installing/uninstalling - if the system is awaiting a reboot due to Windows updates having been installed, or if you are attempting to uninstall the package immediately after installing it. The package will provide informative messages in each case.
 
 If control over reboots is required, please install the dependencies (like dotnet4.6 or later) first, perform a reboot if needed, and then continue with the VS package install.
 </description>
@@ -42,11 +49,11 @@ If control over reboots is required, please install the dependencies (like dotne
 </releaseNotes>
     <tags>Microsoft Visual Studio 2017 Professional IDE VisualStudio VS VS15</tags>
     <dependencies>
+      <dependency id="chocolatey-visualstudio.extension" version="1.0.0" />
       <dependency id="KB3033929" version="1.0.0" />
       <dependency id="KB2919355" version="1.0.20160915" />
-      <dependency id="vcredist2012" version="11.0.60610" />
-      <dependency id="vcredist2015" version="14.0.24215.20160928" />
-      <dependency id="dotnet4.6.1" version="4.6.1055.1" />
+      <dependency id="KB2999226" version="1.0.20161201" />
+      <dependency id="dotnet4.6" version="4.6.00081.20150925" />
     </dependencies>
     <packageSourceUrl>https://github.com/jivkok/Chocolatey-Packages/tree/master/VisualStudio2017Professional</packageSourceUrl>
     <docsUrl>https://www.visualstudio.com/en-us/news/releasenotes/vs15-relnotes</docsUrl>
@@ -54,6 +61,5 @@ If control over reboots is required, please install the dependencies (like dotne
   </metadata>
   <files>
     <file src="Tools\*" target="Tools\" />
-    <file src="..\VisualStudioCommon\VSModules2017.psm1" target="Tools\VSModules.psm1" />
   </files>
 </package>

--- a/VisualStudio2017Professional/VisualStudioProfessional2017.nuspec
+++ b/VisualStudio2017Professional/VisualStudioProfessional2017.nuspec
@@ -3,9 +3,9 @@
   <metadata>
     <id>VisualStudio2017Professional</id>
     <title>Visual Studio 2017 Professional - Release Candidate (2017-02-07)</title>
-    <version>15.0.26206.20170214-rc6</version>
+    <version>15.0.26206.20170228-rc6</version>
     <authors>Microsoft</authors>
-    <owners>Jivko Kolev</owners>
+    <owners>Jivko Kolev,jberezanski</owners>
     <projectUrl>https://www.visualstudio.com/vs/visual-studio-2017-rc</projectUrl>
     <iconUrl>https://github.com/jivkok/Chocolatey-Packages/raw/master/VisualStudioCommon/VS2015.png</iconUrl>
     <licenseUrl>http://msdn.microsoft.com/en-US/cc300389.aspx</licenseUrl>
@@ -49,11 +49,12 @@ If control over reboots is required, please install the dependencies (like dotne
 </releaseNotes>
     <tags>Microsoft Visual Studio 2017 Professional IDE VisualStudio VS VS15</tags>
     <dependencies>
-      <dependency id="chocolatey-visualstudio.extension" version="1.0.0" />
+      <dependency id="chocolatey-visualstudio.extension" version="1.1.0" />
       <dependency id="KB3033929" version="1.0.0" />
       <dependency id="KB2919355" version="1.0.20160915" />
       <dependency id="KB2999226" version="1.0.20161201" />
       <dependency id="dotnet4.6" version="4.6.00081.20150925" />
+      <dependency id="visualstudio2017-installer" version="1.0.0-rc1" />
     </dependencies>
     <packageSourceUrl>https://github.com/jivkok/Chocolatey-Packages/tree/master/VisualStudio2017Professional</packageSourceUrl>
     <docsUrl>https://www.visualstudio.com/en-us/news/releasenotes/vs15-relnotes</docsUrl>

--- a/VisualStudio2017Professional/VisualStudioProfessional2017.nuspec
+++ b/VisualStudio2017Professional/VisualStudioProfessional2017.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>VisualStudio2017Professional</id>
     <title>Visual Studio 2017 Professional</title>
-    <version>15.0.26228.0</version>
+    <version>15.0.26228.20170331</version>
     <authors>Microsoft</authors>
     <owners>Jivko Kolev,jberezanski</owners>
     <projectUrl>https://blogs.msdn.microsoft.com/visualstudio/2017/03/07/announcing-visual-studio-2017-general-availability-and-more/</projectUrl>
@@ -55,6 +55,8 @@ If control over reboots is required, please install the dependencies (like dotne
 </description>
     <releaseNotes>##### Software
 [Visual Studio 2017 release notes](https://www.visualstudio.com/en-us/news/releasenotes/vs2017-relnotes)
+##### Package
+15.0.26228.20170331: Initial package release for Visual Studio 2017 version 15.0.26228.12.
 </releaseNotes>
     <tags>Microsoft Visual Studio 2017 Professional IDE VisualStudio VS VS15 admin</tags>
     <dependencies>

--- a/VisualStudio2017Professional/VisualStudioProfessional2017.nuspec
+++ b/VisualStudio2017Professional/VisualStudioProfessional2017.nuspec
@@ -14,20 +14,11 @@
     <description>### Overview
 Professional developer tools, services, and subscription benefits for small teams.
 
-#### Boosted productivity
-Enhancements to code navigation, IntelliSense, refactoring, code fixes, and debugging, saves you time and effort on everyday tasks regardless of language or platform. In addition, for teams embracing DevOps, Visual Studio 2017 streamlines the developer inner loop and speeds up code flow with the brand new real time features such as live unit testing and real-time architectural dependency validation.
-
-#### Redefined fundamentals
-There is a renewed focus to enhance the efficiency of the fundamental tasks developers encounter on daily basis. From a brand-new lightweight and modular installation tailored to developers’ need, a faster IDE from startup to shut down, to a new way of view, edit, and debug any code without projects and solutions. Visual Studio 2017 helps developers stay focused on the big picture.
-
-#### Streamlined Azure development
-Built-in suite of Azure tools that enable developers to easily create cloud-first applications powered by Microsoft Azure. Visual Studio makes it easy to configure, build, debug, package, and deploy applications and services on Microsoft Azure directly from the IDE.
-
-#### Five-star mobile development
-With advanced debugging and profiling tools and unit test generation features, Visual Studio 2017 with Xamarin makes it faster and easier than ever for developers to build, connect, and tune mobile apps for Android, iOS, and Windows. Developer can also choose to develop mobile apps with Apache Cordova or Visual C++ cross platform library development in Visual Studio.
+To find out what's new or to see the known issues, see the [Visual Studio 2017 Release Notes](https://www.visualstudio.com/en-us/news/releasenotes/vs2017-relnotes).  
+[System requirements](https://www.visualstudio.com/en-us/productinfo/vs2017-system-requirements-vs)
 
 ### Customizations and Optional features
-By default, the package installs only the bare minimum required (the Core Editor workload). The easiest way to add more workloads (feature sets) is to use the workload packages:
+By default, the package installs only the bare minimum required (the Core Editor workload). The easiest way to add more development features is to use the workload packages:
 - [Azure development](https://chocolatey.org/packages/visualstudio2017-workload-azure)
 - [Data storage and processing](https://chocolatey.org/packages/visualstudio2017-workload-data)
 - [.NET desktop development](https://chocolatey.org/packages/visualstudio2017-workload-manageddesktop)
@@ -45,22 +36,21 @@ By default, the package installs only the bare minimum required (the Core Editor
 - [Visual Studio extension development](https://chocolatey.org/packages/visualstudio2017-workload-visualstudioextension)
 - [Mobile development with JavaScript](https://chocolatey.org/packages/visualstudio2017-workload-webcrossplat)
 
-However, the package passes all package parameters to the Visual Studio installer, enabling full customization of the installation. The possible parameters are [described here](https://docs.microsoft.com/en-us/visualstudio/install/use-command-line-parameters-to-install-visual-studio). The package passes `--norestart --wait` by default, and `--quiet`, unless `--passive` is specified in the package parameters.
+All package parameters are passed to the Visual Studio installer, enabling full customization of the installation. The possible parameters are [described here](https://docs.microsoft.com/en-us/visualstudio/install/use-command-line-parameters-to-install-visual-studio). The package passes `--norestart --wait` by default, and `--quiet`, unless `--passive` is specified in the package parameters.
 
-After installing the package, more workloads/components can also be added interactively, by launching the Visual Studio Installer application from the Start Menu.
+After installing the package, more features can also be added by launching the Visual Studio Installer application from the Start Menu.
 
 The language of the installed software can be controlled using the package parameter `--locale &lt;language&gt;`.
-The list of supported languages is [presented here](https://docs.microsoft.com/en-us/visualstudio/install/use-command-line-parameters-to-install-visual-studio#list-of-language-locales). By default, the operating system display language is used.
+The list of languages is [presented here](https://docs.microsoft.com/en-us/visualstudio/install/use-command-line-parameters-to-install-visual-studio#list-of-language-locales). By default, the operating system display language is used.
 
 #### Full installation
-As an example of using package parameters, this command will install Visual Studio with all available workloads and optional components, display progress during the installation and specify the English language regardless of operating system settings:
+This command will install Visual Studio with all available workloads and optional components, display progress during the installation and specify the English language regardless of operating system settings:
 
     choco install visualstudio2017professional --package-parameters "--allWorkloads --includeRecommended --includeOptional --passive --locale en-US"
 
-### Installation notes
+### Notes
 
-A reboot may be required after installing/uninstalling this package. A reboot might even be required _before_ installing/uninstalling - if the system is awaiting a reboot due to Windows updates having been installed, or if you are attempting to uninstall the package immediately after installing it. The package will provide informative messages in each case.
-
+A reboot may be required after (or even _before_) installing/uninstalling this package.
 If control over reboots is required, please install the dependencies (like dotnet4.6.1 or later) first, perform a reboot if needed, and then continue with the VS package install.
 </description>
     <releaseNotes>##### Software

--- a/VisualStudio2017Professional/VisualStudioProfessional2017.nuspec
+++ b/VisualStudio2017Professional/VisualStudioProfessional2017.nuspec
@@ -2,17 +2,17 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>VisualStudio2017Professional</id>
-    <title>Visual Studio 2017 Professional - Release Candidate (2017-02-07)</title>
-    <version>15.0.26206.20170228-rc6</version>
+    <title>Visual Studio 2017 Professional</title>
+    <version>15.0.26228.0</version>
     <authors>Microsoft</authors>
     <owners>Jivko Kolev,jberezanski</owners>
-    <projectUrl>https://www.visualstudio.com/vs/visual-studio-2017-rc</projectUrl>
-    <iconUrl>https://github.com/jivkok/Chocolatey-Packages/raw/master/VisualStudioCommon/VS2015.png</iconUrl>
-    <licenseUrl>http://msdn.microsoft.com/en-US/cc300389.aspx</licenseUrl>
+    <projectUrl>https://blogs.msdn.microsoft.com/visualstudio/2017/03/07/announcing-visual-studio-2017-general-availability-and-more/</projectUrl>
+    <iconUrl>https://cdn.rawgit.com/jberezanski/ChocolateyPackages/17d25f2fb8a31d40b93a696e345c22a77913418f/icons/vs2017.png</iconUrl>
+    <licenseUrl>https://www.visualstudio.com/license-terms/mlt687465/</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <summary>Free, full-featured and extensible tool for students, open-source and individual developers</summary>
+    <summary>Professional developer tools, services, and subscription benefits for small teams</summary>
     <description>### Overview
-Free, full-featured and extensible tool for students, open-source and individual developers.
+Professional developer tools, services, and subscription benefits for small teams.
 
 #### Boosted productivity
 Enhancements to code navigation, IntelliSense, refactoring, code fixes, and debugging, saves you time and effort on everyday tasks regardless of language or platform. In addition, for teams embracing DevOps, Visual Studio 2017 streamlines the developer inner loop and speeds up code flow with the brand new real time features such as live unit testing and real-time architectural dependency validation.
@@ -27,37 +27,56 @@ Built-in suite of Azure tools that enable developers to easily create cloud-firs
 With advanced debugging and profiling tools and unit test generation features, Visual Studio 2017 with Xamarin makes it faster and easier than ever for developers to build, connect, and tune mobile apps for Android, iOS, and Windows. Developer can also choose to develop mobile apps with Apache Cordova or Visual C++ cross platform library development in Visual Studio.
 
 ### Customizations and Optional features
-By default, the package installs only the bare minimum required (the Core Editor workload). The easiest way to add more workloads is to use the workload packages: `visualstudio2017-workload-*`, e.g. [visualstudio2017-workload-manageddesktop](https://chocolatey.org/packages/visualstudio2017-workload-manageddesktop).
+By default, the package installs only the bare minimum required (the Core Editor workload). The easiest way to add more workloads (feature sets) is to use the workload packages:
+- [Azure development](https://chocolatey.org/packages/visualstudio2017-workload-azure)
+- [Data storage and processing](https://chocolatey.org/packages/visualstudio2017-workload-data)
+- [.NET desktop development](https://chocolatey.org/packages/visualstudio2017-workload-manageddesktop)
+- [Game development with Unity](https://chocolatey.org/packages/visualstudio2017-workload-managedgame)
+- [Linux development with C++](https://chocolatey.org/packages/visualstudio2017-workload-nativecrossplat)
+- [Desktop development with C++](https://chocolatey.org/packages/visualstudio2017-workload-nativedesktop)
+- [Game development with C++](https://chocolatey.org/packages/visualstudio2017-workload-nativegame)
+- [Mobile development with C++](https://chocolatey.org/packages/visualstudio2017-workload-nativemobile)
+- [.NET Core cross-platform development](https://chocolatey.org/packages/visualstudio2017-workload-netcoretools)
+- [Mobile development with .NET](https://chocolatey.org/packages/visualstudio2017-workload-netcrossplat)
+- [ASP.NET and web development](https://chocolatey.org/packages/visualstudio2017-workload-netweb)
+- [Node.js development](https://chocolatey.org/packages/visualstudio2017-workload-node)
+- [Office/SharePoint development](https://chocolatey.org/packages/visualstudio2017-workload-office)
+- [Universal Windows Platform development](https://chocolatey.org/packages/visualstudio2017-workload-universal)
+- [Visual Studio extension development](https://chocolatey.org/packages/visualstudio2017-workload-visualstudioextension)
+- [Mobile development with JavaScript](https://chocolatey.org/packages/visualstudio2017-workload-webcrossplat)
 
 However, the package passes all package parameters to the Visual Studio installer, enabling full customization of the installation. The possible parameters are [described here](https://docs.microsoft.com/en-us/visualstudio/install/use-command-line-parameters-to-install-visual-studio). The package passes `--norestart --wait` by default, and `--quiet`, unless `--passive` is specified in the package parameters.
 
 After installing the package, more workloads/components can also be added interactively, by launching the Visual Studio Installer application from the Start Menu.
 
-#### Full installation
-As an example of using package parameters, this command will install Visual Studio with all available workloads and optional components and display progress during the installation:
+The language of the installed software can be controlled using the package parameter `--locale &lt;language&gt;`.
+The list of supported languages is [presented here](https://docs.microsoft.com/en-us/visualstudio/install/use-command-line-parameters-to-install-visual-studio#list-of-language-locales). By default, the operating system display language is used.
 
-    choco install visualstudio2017professional -packageParameters "--allWorkloads --includeRecommended --includeOptional --passive"
+#### Full installation
+As an example of using package parameters, this command will install Visual Studio with all available workloads and optional components, display progress during the installation and specify the English language regardless of operating system settings:
+
+    choco install visualstudio2017professional --package-parameters "--allWorkloads --includeRecommended --includeOptional --passive --locale en-US"
 
 ### Installation notes
 
 A reboot may be required after installing/uninstalling this package. A reboot might even be required _before_ installing/uninstalling - if the system is awaiting a reboot due to Windows updates having been installed, or if you are attempting to uninstall the package immediately after installing it. The package will provide informative messages in each case.
 
-If control over reboots is required, please install the dependencies (like dotnet4.6 or later) first, perform a reboot if needed, and then continue with the VS package install.
+If control over reboots is required, please install the dependencies (like dotnet4.6.1 or later) first, perform a reboot if needed, and then continue with the VS package install.
 </description>
     <releaseNotes>##### Software
-[Visual Studio 2017 RC release notes](https://www.visualstudio.com/news/releasenotes/vs15-relnotes)
+[Visual Studio 2017 release notes](https://www.visualstudio.com/en-us/news/releasenotes/vs2017-relnotes)
 </releaseNotes>
-    <tags>Microsoft Visual Studio 2017 Professional IDE VisualStudio VS VS15</tags>
+    <tags>Microsoft Visual Studio 2017 Professional IDE VisualStudio VS VS15 admin</tags>
     <dependencies>
-      <dependency id="chocolatey-visualstudio.extension" version="1.1.0" />
+      <dependency id="chocolatey-visualstudio.extension" version="1.2.0" />
       <dependency id="KB3033929" version="1.0.0" />
       <dependency id="KB2919355" version="1.0.20160915" />
       <dependency id="KB2999226" version="1.0.20161201" />
-      <dependency id="dotnet4.6" version="4.6.00081.20150925" />
-      <dependency id="visualstudio2017-installer" version="1.0.0-rc1" />
+      <dependency id="dotnet4.6.1" version="4.6.01055.20161213" />
+      <dependency id="visualstudio2017-installer" version="1.0.0" />
     </dependencies>
     <packageSourceUrl>https://github.com/jivkok/Chocolatey-Packages/tree/master/VisualStudio2017Professional</packageSourceUrl>
-    <docsUrl>https://www.visualstudio.com/en-us/news/releasenotes/vs15-relnotes</docsUrl>
+    <docsUrl>https://docs.microsoft.com/en-us/visualstudio/welcome-to-visual-studio</docsUrl>
     <bugTrackerUrl>https://visualstudio.uservoice.com/forums/121579-visual-studio</bugTrackerUrl>
   </metadata>
   <files>


### PR DESCRIPTION
I've published a [Chocolatey extension](https://chocolatey.org/packages/chocolatey-visualstudio.extension) encapsulating the helper functions for installing/modifying Visual Studio. The extension supports silent installation and selecting optional workloads/components using package parameters.

Additionally, this PR updates the dependencies to include only packages required by the minimal Visual Studio installation.

Visual Studio URLs are updated to point to the RC update from 2017-02-07. (The final links are used instead of aka.ms so that hopefully the binaries stay stable, checksums match and always the expected version gets installed.)